### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PCGestureUnlock
 ===================
-###目前最全面最高仿支付宝的手势解锁，而且提供方法进行参数修改，能解决项目开发中所有手势解锁的开发
+### 目前最全面最高仿支付宝的手势解锁，而且提供方法进行参数修改，能解决项目开发中所有手势解锁的开发
 ------------------
 宣言：不仅仅是支付宝手势解锁，它很好很强大~
 
@@ -10,31 +10,31 @@
 
 框架特点：面向实际项目开发，修改参数(PCCircleViewConst.h文件中)即可实现实际需求
 
-###设置密码：
+### 设置密码：
 
 ![ABC](https://github.com/iosdeveloperpanc/PCGestureUnlock/blob/master/PCGestureUnlock/settingGesture.gif) 
 
-###细节处理之全方向箭头
+### 细节处理之全方向箭头
 
 ![ABC](https://github.com/iosdeveloperpanc/PCGestureUnlock/blob/master/PCGestureUnlock/arrowDirctions.gif) 
 
-###细节处理之错误绘制
+### 细节处理之错误绘制
 
 ![ABC](https://github.com/iosdeveloperpanc/PCGestureUnlock/blob/master/PCGestureUnlock/ErrorDisplay.gif) 
 
-###细节处理之跳跃连线
+### 细节处理之跳跃连线
 
 ![ABC](https://github.com/iosdeveloperpanc/PCGestureUnlock/blob/master/PCGestureUnlock/JumpConnect.gif) 
 
-###框架使用说明：
+### 框架使用说明：
 使用前说明：
 解锁界面（PCCircleView）可以实例化出特定使用的类型界面，实现以下方法即可
 // 初始化方法（设置view的相关类型、参数）
     - (instancetype)initWithType:(CircleViewType)type clip:(BOOL)clip arrow:(BOOL)arrow;
 clip代表圆内是否剪切 arrow代表是否有三角箭头
 
-###1.包含框架文件：（FrameWork）
-###2.在使用到的控制器中实现以下方法：
+### 1.包含框架文件：（FrameWork）
+### 2.在使用到的控制器中实现以下方法：
       - (void)viewDidLoad {
       [super viewDidLoad];
       // Do any additional setup after loading the view.
@@ -100,6 +100,6 @@ clip代表圆内是否剪切 arrow代表是否有三角箭头
     }
 
 
-#PCGestureUnlock 手势解锁终结者
+# PCGestureUnlock 手势解锁终结者
 ------------
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
